### PR TITLE
Spaceruin et Whiteship tweak

### DIFF
--- a/_maps/gardenstation.json
+++ b/_maps/gardenstation.json
@@ -6,7 +6,7 @@
 	"shuttles": {
 		"cargo": "cargo_gardenstation",
 		"ferry": "ferry_fancy",
-		"whiteship": "whiteship_box",
+		"whiteship": "whiteship_meta",
 		"emergency": "emergency_gardenstation"
 	},
 	"traits": [

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -332,7 +332,7 @@
 	min_val = 0
 
 /datum/config_entry/number/space_budget
-	default = 16
+	default = 32
 	integer = FALSE
 	min_val = 0
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -332,7 +332,7 @@
 	min_val = 0
 
 /datum/config_entry/number/space_budget
-	default = 32
+	default = 16
 	integer = FALSE
 	min_val = 0
 

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -289,6 +289,7 @@
 	suffix = "whiteshipdock.dmm"
 	name = "Whiteship Dock"
 	description = "An abandoned but functional vessel parked in deep space, ripe for the taking."
+	always_place = TRUE
 
 /datum/map_template/ruin/space/cat_experiments
 	id = "meow"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -288,6 +288,8 @@
 	id = "whiteshipdock"
 	suffix = "whiteshipdock.dmm"
 	name = "Whiteship Dock"
+	cost = 0
+	placement_weight = 10
 	description = "An abandoned but functional vessel parked in deep space, ripe for the taking."
 	always_place = TRUE
 

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -289,7 +289,6 @@
 	suffix = "whiteshipdock.dmm"
 	name = "Whiteship Dock"
 	cost = 0
-	placement_weight = 10
 	description = "An abandoned but functional vessel parked in deep space, ripe for the taking."
 	always_place = TRUE
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -367,15 +367,10 @@
 	dir = 2
 	shuttlekeys = list(
 		"whiteship_meta",
-		"whiteship_pubby",
 		"whiteship_box",
 		"whiteship_cere",
-		"whiteship_kilo",
 		"whiteship_donut",
 		"whiteship_delta",
-		"whiteship_tram",
-		"whiteship_personalshuttle",
-		"whiteship_obelisk",
 	)
 
 /// Helper proc that tests to ensure all whiteship templates can spawn at their docking port, and logs their sizes

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -459,7 +459,7 @@ LAVALAND_BUDGET 120
 ICEMOON_BUDGET 90
 
 ## Space Ruin Budget
-Space_Budget 16
+Space_Budget 32
 
 ## Time in ds from when a player latejoins till the arrival shuttle docks at the station
 ## Must be at least 30. At least 55 recommended to be visually/aurally appropriate


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Double le budget de l'espace qui est sacrément vide sinon.
Rend le spawn de whiteship dans l'espace lointain garantie, réduit le pool de spawn de whiteship aux whiteships qui sont cool conceptuellement. 

## Why It's Good For The Game

Vrrrmmm vrrrrrrrrmmmmmm piou piou vaisseau spatial

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: le whiteship est garantie de spawner comme une space ruin
del: seuls les variants de whiteship meta, box, cere, donut et delta apparaitront naturellement dans l'espace
config: Deux fois plus de ruines dans l'espace
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
